### PR TITLE
Build only for DLX, prevent conflicts with other devices

### DIFF
--- a/bluetooth/Android.mk
+++ b/bluetooth/Android.mk
@@ -1,3 +1,4 @@
+ifeq ($(TARGET_BOOTLOADER_BOARD_NAME),dlx)
 LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
@@ -12,3 +13,4 @@ LOCAL_SRC_FILES := $(LOCAL_MODULE)
 
 include $(BUILD_PREBUILT)
 
+endif


### PR DESCRIPTION
Help prevent device conflicts with bt_vendor.conf module name.
